### PR TITLE
Retaining the modified title on component unmount made optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
-let { useState, useEffect } = require('react');
+let { useRef, useEffect } = require('react');
 
 function useDocumentTitle(title, retainOnUnmount = false) {
-  const [defaultTitle, ,] = useState(document.title);
+  const defaultTitle = useRef(document.title);
 
   useEffect(() => {
     document.title = title;
 
     return () => {
-      if (!retainOnUnmount) document.title = defaultTitle;
+      if (!retainOnUnmount) document.title = defaultTitle.current;
     };
   }, [title]);
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
 'use strict';
-let { useEffect } = require('react');
+let { useState, useEffect } = require('react');
 
-function useDocumentTitle(title) {
+function useDocumentTitle(title, retainOnUnmount = false) {
+  const [defaultTitle, ,] = useState(document.title);
+
   useEffect(() => {
     document.title = title;
-  }, [title])
+
+    return () => {
+      if (!retainOnUnmount) document.title = defaultTitle;
+    };
+  }, [title]);
 }
 
 module.exports = useDocumentTitle;


### PR DESCRIPTION
Option added to retain the modified title or to rollback to the default title ON the corresponding component unmount event (e.g. route change -> title change for those using this hook, but rollback to the default/original title for those routes not using this hook.)