### PR TITLE
Make sure original document.title is restored only on unmount

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 interface DocumentTitle {}
 
-export default function useDocumentTitle(title: string): DocumentTitle;
+export default function useDocumentTitle(title: string, retainOnUnmount?: boolean): DocumentTitle;

--- a/index.js
+++ b/index.js
@@ -6,11 +6,15 @@ function useDocumentTitle(title, retainOnUnmount = false) {
 
   useEffect(() => {
     document.title = title;
-
-    return () => {
-      if (!retainOnUnmount) document.title = defaultTitle.current;
-    };
   }, [title]);
+
+  useEffect(() => {
+    return () => {
+      if (!retainOnUnmount) {
+        document.title = defaultTitle.current;
+      }
+    };
+  }, []);
 }
 
 module.exports = useDocumentTitle;

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,4 +1,4 @@
 interface DocumentTitle {}
-declare function useDocumentTitle(title: string): DocumentTitle;
+declare function useDocumentTitle(title: string, retainOnUnmount?: boolean): DocumentTitle;
 
 export default useDocumentTitle;


### PR DESCRIPTION
With current implementation, `if (!retainOnUnmount) document.title = defaultTitle.current;` is called on every `title` change, not only when the component is unmounted. This PR fixes that.