### PR TITLE
Remove warning signs in useDocumentTitle hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ function useDocumentTitle(title, retainOnUnmount = false) {
   }, [title]);
 
   useEffect(() => {
+    const defaultTitleCurrent = defaultTitle.current;
     return () => {
       if (!retainOnUnmount) {
-        document.title = defaultTitle.current;
+        document.title = defaultTitleCurrent;
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }
 


### PR DESCRIPTION
These changes remove the dependency warnings that arise in 16.8.6+.